### PR TITLE
feat: apply cluster per instance group

### DIFF
--- a/pkg/api/resources/ClusterUpdater.go
+++ b/pkg/api/resources/ClusterUpdater.go
@@ -39,23 +39,7 @@ type ClusterUpdater struct {
 	ValidateCount *int
 }
 
-func applyCluster(name string, clientset simple.Clientset) error {
-	kc, err := clientset.GetCluster(context.Background(), name)
-	if err != nil {
-		return err
-	}
-	apply := &cloudup.ApplyClusterCmd{
-		Cluster:    kc,
-		Clientset:  clientset,
-		TargetName: cloudup.TargetDirect,
-	}
-	return apply.Run(context.Background())
-}
-
 func (u *ClusterUpdater) Apply(clientset simple.Clientset) error {
-	if err := applyCluster(u.ClusterName, clientset); err != nil {
-		return err
-	}
 	kc, err := clientset.GetCluster(context.Background(), u.ClusterName)
 	if err != nil {
 		return err

--- a/pkg/api/resources/InstanceGroup.go
+++ b/pkg/api/resources/InstanceGroup.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"context"
 
+	"github.com/eddycharly/terraform-provider-kops/pkg/api/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kops/pkg/apis/kops"
 	"k8s.io/kops/pkg/client/simple"
@@ -55,6 +56,10 @@ func CreateInstanceGroup(clusterName, name string, spec kops.InstanceGroupSpec, 
 	if err != nil {
 		return nil, err
 	}
+	if err := utils.ClusterApply(cluster, clientset, instanceGroup); err != nil {
+		return nil, err
+
+	}
 	return makeInstanceGroup(clusterName, instanceGroup), nil
 }
 
@@ -66,6 +71,10 @@ func UpdateInstanceGroup(clusterName, name string, spec kops.InstanceGroupSpec, 
 	instanceGroup, err := clientset.InstanceGroupsFor(cluster).Update(context.Background(), makeKopsInstanceGroup(name, spec), metav1.UpdateOptions{})
 	if err != nil {
 		return nil, err
+	}
+	if err := utils.ClusterApply(cluster, clientset, instanceGroup); err != nil {
+		return nil, err
+
 	}
 	return makeInstanceGroup(clusterName, instanceGroup), nil
 }

--- a/pkg/api/utils/cluster.go
+++ b/pkg/api/utils/cluster.go
@@ -67,6 +67,16 @@ func ClusterExists(name string, clientset simple.Clientset) (bool, error) {
 	return true, nil
 }
 
+func ClusterApply(cluster *kops.Cluster, clientset simple.Clientset, instanceGroups ...*kops.InstanceGroup) error {
+	apply := &cloudup.ApplyClusterCmd{
+		Cluster:        cluster,
+		InstanceGroups: instanceGroups,
+		Clientset:      clientset,
+		TargetName:     cloudup.TargetDirect,
+	}
+	return apply.Run(context.Background())
+}
+
 func IsClusterValid(name string, clientset simple.Clientset) (bool, error) {
 	if validator, err := makeValidator(name, clientset); err != nil {
 		return false, err


### PR DESCRIPTION
This PR applies cluster per instance group.
This is obviously not going to work as is because `cloudup.ApplyClusterCmd` needs to know at least 1 master and 1 worker node.