### PR TITLE
Update provider for arm64

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,6 +17,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
   - format: zip


### PR DESCRIPTION
Update provider for arm64.
Addresses: https://github.com/eddycharly/terraform-provider-kops/issues/349