### PR TITLE
chore: remove provider version from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ terraform {
   required_providers {
     kops = {
       source  = "eddycharly/kops"
-      version = "1.21.0-alpha.7"
     }
   }
 }


### PR DESCRIPTION
This PR removes provider version from `README`.