### PR TITLE
bump: golang 1.19

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Checkout code
         uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.19
       - name: Import GPG key
         id: import_gpg
         uses: paultyng/ghaction-import-gpg@v2.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/eddycharly/terraform-provider-kops
 
-go 1.18
+go 1.19
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible


### PR DESCRIPTION
This PR bumps golang to version 1.19