### PR TITLE
kops_cluster_updater: add instance group filtering to rolling updates

### DIFF
--- a/docs/resources/cluster_updater.md
+++ b/docs/resources/cluster_updater.md
@@ -121,6 +121,7 @@ The following arguments are supported:
 - `bastion_interval` - (Optional) - Duration - BastionInterval is the amount of time to wait after stopping a bastion instance.
 - `fail_on_drain_error` - (Optional) - Bool - FailOnDrainError will fail when a drain error occurs.
 - `fail_on_validate` - (Optional) - Bool - FailOnValidate will fail when a validation error occurs.
+- `instance_groups` - (Optional) - List(String) - InstanceGroups will limit the rolling update to only the instance groups in this list.
 - `post_drain_delay` - (Optional) - Duration - PostDrainDelay is the duration we wait after draining each node.
 - `validation_timeout` - (Optional) - Duration - ValidationTimeout is the maximum time to wait for the cluster to validate, once we start validation.
 - `validate_count` - (Optional) - Int - ValidateCount is the amount of time that a cluster needs to be validated after single node update.

--- a/pkg/schemas/resources/Resource_RollingUpdateOptions.generated.go
+++ b/pkg/schemas/resources/Resource_RollingUpdateOptions.generated.go
@@ -19,6 +19,7 @@ func ResourceRollingUpdateOptions() *schema.Resource {
 			"bastion_interval":    OptionalDuration(),
 			"fail_on_drain_error": OptionalBool(),
 			"fail_on_validate":    OptionalBool(),
+			"instance_groups":     OptionalList(String()),
 			"post_drain_delay":    OptionalDuration(),
 			"validation_timeout":  OptionalDuration(),
 			"validate_count":      OptionalInt(),

--- a/pkg/schemas/resources/Resource_RollingUpdateOptions.generated_test.go
+++ b/pkg/schemas/resources/Resource_RollingUpdateOptions.generated_test.go
@@ -27,6 +27,7 @@ func TestExpandResourceRollingUpdateOptions(t *testing.T) {
 					"bastion_interval":    nil,
 					"fail_on_drain_error": false,
 					"fail_on_validate":    false,
+					"instance_groups":     func() []interface{} { return nil }(),
 					"post_drain_delay":    nil,
 					"validation_timeout":  nil,
 					"validate_count":      nil,
@@ -55,6 +56,7 @@ func TestFlattenResourceRollingUpdateOptionsInto(t *testing.T) {
 		"bastion_interval":    nil,
 		"fail_on_drain_error": false,
 		"fail_on_validate":    false,
+		"instance_groups":     func() []interface{} { return nil }(),
 		"post_drain_delay":    nil,
 		"validation_timeout":  nil,
 		"validate_count":      nil,
@@ -137,6 +139,17 @@ func TestFlattenResourceRollingUpdateOptionsInto(t *testing.T) {
 				in: func() resources.RollingUpdateOptions {
 					subject := resources.RollingUpdateOptions{}
 					subject.FailOnValidate = false
+					return subject
+				}(),
+			},
+			want: _default,
+		},
+		{
+			name: "InstanceGroups - default",
+			args: args{
+				in: func() resources.RollingUpdateOptions {
+					subject := resources.RollingUpdateOptions{}
+					subject.InstanceGroups = nil
 					return subject
 				}(),
 			},
@@ -217,6 +230,7 @@ func TestFlattenResourceRollingUpdateOptions(t *testing.T) {
 		"bastion_interval":    nil,
 		"fail_on_drain_error": false,
 		"fail_on_validate":    false,
+		"instance_groups":     func() []interface{} { return nil }(),
 		"post_drain_delay":    nil,
 		"validation_timeout":  nil,
 		"validate_count":      nil,
@@ -299,6 +313,17 @@ func TestFlattenResourceRollingUpdateOptions(t *testing.T) {
 				in: func() resources.RollingUpdateOptions {
 					subject := resources.RollingUpdateOptions{}
 					subject.FailOnValidate = false
+					return subject
+				}(),
+			},
+			want: _default,
+		},
+		{
+			name: "InstanceGroups - default",
+			args: args{
+				in: func() resources.RollingUpdateOptions {
+					subject := resources.RollingUpdateOptions{}
+					subject.InstanceGroups = nil
 					return subject
 				}(),
 			},

--- a/pkg/schemas/utils/Resource_RollingUpdateOptions.generated.go
+++ b/pkg/schemas/utils/Resource_RollingUpdateOptions.generated.go
@@ -78,6 +78,18 @@ func ExpandResourceRollingUpdateOptions(in map[string]interface{}) utils.Rolling
 		FailOnValidate: func(in interface{}) bool {
 			return bool(ExpandBool(in))
 		}(in["fail_on_validate"]),
+		InstanceGroups: func(in interface{}) []string {
+			return func(in interface{}) []string {
+				if in == nil {
+					return nil
+				}
+				var out []string
+				for _, in := range in.([]interface{}) {
+					out = append(out, string(ExpandString(in)))
+				}
+				return out
+			}(in)
+		}(in["instance_groups"]),
 		PostDrainDelay: func(in interface{}) *meta.Duration {
 			if in == nil {
 				return nil
@@ -181,6 +193,15 @@ func FlattenResourceRollingUpdateOptionsInto(in utils.RollingUpdateOptions, out 
 	out["fail_on_validate"] = func(in bool) interface{} {
 		return FlattenBool(bool(in))
 	}(in.FailOnValidate)
+	out["instance_groups"] = func(in []string) interface{} {
+		return func(in []string) []interface{} {
+			var out []interface{}
+			for _, in := range in {
+				out = append(out, FlattenString(string(in)))
+			}
+			return out
+		}(in)
+	}(in.InstanceGroups)
 	out["post_drain_delay"] = func(in *meta.Duration) interface{} {
 		return func(in *meta.Duration) interface{} {
 			if in == nil {

--- a/pkg/schemas/utils/Resource_RollingUpdateOptions.generated_test.go
+++ b/pkg/schemas/utils/Resource_RollingUpdateOptions.generated_test.go
@@ -26,6 +26,7 @@ func TestExpandResourceRollingUpdateOptions(t *testing.T) {
 					"bastion_interval":    nil,
 					"fail_on_drain_error": false,
 					"fail_on_validate":    false,
+					"instance_groups":     func() []interface{} { return nil }(),
 					"post_drain_delay":    nil,
 					"validation_timeout":  nil,
 					"validate_count":      nil,
@@ -53,6 +54,7 @@ func TestFlattenResourceRollingUpdateOptionsInto(t *testing.T) {
 		"bastion_interval":    nil,
 		"fail_on_drain_error": false,
 		"fail_on_validate":    false,
+		"instance_groups":     func() []interface{} { return nil }(),
 		"post_drain_delay":    nil,
 		"validation_timeout":  nil,
 		"validate_count":      nil,
@@ -124,6 +126,17 @@ func TestFlattenResourceRollingUpdateOptionsInto(t *testing.T) {
 				in: func() utils.RollingUpdateOptions {
 					subject := utils.RollingUpdateOptions{}
 					subject.FailOnValidate = false
+					return subject
+				}(),
+			},
+			want: _default,
+		},
+		{
+			name: "InstanceGroups - default",
+			args: args{
+				in: func() utils.RollingUpdateOptions {
+					subject := utils.RollingUpdateOptions{}
+					subject.InstanceGroups = nil
 					return subject
 				}(),
 			},
@@ -203,6 +216,7 @@ func TestFlattenResourceRollingUpdateOptions(t *testing.T) {
 		"bastion_interval":    nil,
 		"fail_on_drain_error": false,
 		"fail_on_validate":    false,
+		"instance_groups":     func() []interface{} { return nil }(),
 		"post_drain_delay":    nil,
 		"validation_timeout":  nil,
 		"validate_count":      nil,
@@ -274,6 +288,17 @@ func TestFlattenResourceRollingUpdateOptions(t *testing.T) {
 				in: func() utils.RollingUpdateOptions {
 					subject := utils.RollingUpdateOptions{}
 					subject.FailOnValidate = false
+					return subject
+				}(),
+			},
+			want: _default,
+		},
+		{
+			name: "InstanceGroups - default",
+			args: args{
+				in: func() utils.RollingUpdateOptions {
+					subject := utils.RollingUpdateOptions{}
+					subject.InstanceGroups = nil
 					return subject
 				}(),
 			},


### PR DESCRIPTION
Adds the `instance_groups` attribute to `rolling_update_options` that, if set, only runs the rolling update on the specified IGs.

Equivalent to running `kops rolling-update cluster --instance-groups=<ig1>,<ig2>,... --yes`

Closes #1113 